### PR TITLE
[SW-78.part] Versioning part two

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.savi.geo</groupId>
     <artifactId>Java-TzWhere</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
*This should not be merged until all Savi client modules that use Java-TzWhere have been updated to use a released version*