### PR TITLE
Update Artifactory plugin version 2.2.1 from 2.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.jfrog.buildinfo</groupId>
                 <artifactId>artifactory-maven-plugin</artifactId>
-                <version>2.6.1</version>
+                <version>2.2.1</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>


### PR DESCRIPTION
Hi @savi-jstamm,

Please review and merge the change to fix the Artifactory dependency version to `2.2.1` from `2.6.1`, based on the latest version in [Maven repository](https://mvnrepository.com/artifact/org.jfrog.buildinfo/artifactory-maven-plugin).